### PR TITLE
Specify multiple languages as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or
 Available commands:
 
 ```
-update | Update      Update all gitignore configuration
+update | Update      Update all gitignore configurations
 list                 List available gitignore
 -i | input           Gitignore input
 -o | output          Gitignore output filename
@@ -43,7 +43,7 @@ $ gitnore list
 Output
 
 ```
-List avaiables gitignore:
+Available gitignore configurations:
 actionscript, ada, agda, android, appceleratortitanium, appengine, archlinuxpackages, autotools, c, c++,
 cakephp, cfwheels, chefcookbook, clojure, cmake, codeigniter, commonlisp, composer, concrete5, coq,
 craftcms, cuda, d, dart, delphi, dm, drupal, eagle, elisp, elixir, elm, episerver, erlang,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ list                 List available gitignore
 $ gitnore -i go   # gitignore for golang
 ```
 
+### With multiple languages
+
+```
+$ gitnore -i java,node,r   # comma separated list of languages
+```
+
 ### Update Map File
 
 ```

--- a/gitnore.go
+++ b/gitnore.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	// setup source dir
-	source_dir = fmt.Sprintf("%s/.gitnore", user.HomeDir)
+	sourceDir = fmt.Sprintf("%s/.gitnore", user.HomeDir)
 
 	cmd := os.Args[1]
 

--- a/gitnore.go
+++ b/gitnore.go
@@ -98,11 +98,12 @@ func usage() {
 	fmt.Println("\tlist \t: List available gitignore")
 	fmt.Println()
 	fmt.Println("Parameters:")
-	fmt.Println("\t-i \t: Select Language (-i python)")
+	fmt.Println("\t-i \t: Select Language (-i python or -i java,go)")
 	fmt.Println("\t-o \t: Output filename (default .gitignore)")
 	fmt.Println()
 	fmt.Println("Example usage:")
 	fmt.Println("\t$ gitnore -i python \t\t: default set to .gitignore")
+	fmt.Println("\t$ gitnore -i java,go \t\t: with multiple languages")
 	fmt.Println("\t$ gitnore -i go -o .gitmodule \t: set output file to .gitmodule")
 	os.Exit(1)
 }

--- a/gitnore.go
+++ b/gitnore.go
@@ -91,6 +91,6 @@ func usage() {
 	fmt.Println()
 	fmt.Println("Example usage:")
 	fmt.Println("\t$ gitnore -i python \t\t: default set to .gitignore")
-	fmt.Println("\t$ gitnore -i go -u .gitmodule \t: set output file to .gitmodule")
+	fmt.Println("\t$ gitnore -i go -o .gitmodule \t: set output file to .gitmodule")
 	os.Exit(1)
 }

--- a/map.go
+++ b/map.go
@@ -14,31 +14,31 @@ import (
 	"github.com/google/go-github/github"
 )
 
-var source_dir string
+var sourceDir string
 
 func updateMap() {
-	var raw_dir = fmt.Sprintf("%s/raw", source_dir)
-	if _, err := os.Stat(source_dir); err != nil && os.IsNotExist(err) {
-		if err = os.Mkdir(source_dir, 0700); err != nil {
+	var rawDir = fmt.Sprintf("%s/raw", sourceDir)
+	if _, err := os.Stat(sourceDir); err != nil && os.IsNotExist(err) {
+		if err = os.Mkdir(sourceDir, 0700); err != nil {
 			fmt.Printf("Error when updating map file: %s\n", err.Error())
 			os.Exit(1)
 		}
-		if err = os.Mkdir(raw_dir, 0700); err != nil {
+		if err = os.Mkdir(rawDir, 0700); err != nil {
 			fmt.Printf("Error when updating map file: %s\n", err.Error())
 			os.Exit(1)
 		}
 	}
 	ctx := context.Background()
 	client := github.NewClient(nil)
-	_, dir_contents, _, err := client.Repositories.GetContents(ctx, "valutac", "gitnore", "/config", nil)
+	_, dirContents, _, err := client.Repositories.GetContents(ctx, "valutac", "gitnore", "/config", nil)
 	if err != nil {
 		fmt.Printf("Error when updating map file: %s\n", err.Error())
 		os.Exit(1)
 	}
 
 	dl := grab.NewClient()
-	for _, content := range dir_contents {
-		req, _ := grab.NewRequest(raw_dir, content.GetDownloadURL())
+	for _, content := range dirContents {
+		req, _ := grab.NewRequest(rawDir, content.GetDownloadURL())
 		resp := dl.Do(req)
 		t := time.NewTicker(500 * time.Millisecond)
 		defer t.Stop()
@@ -62,7 +62,7 @@ func updateMap() {
 		fmt.Printf("Download saved to %s \n", resp.Filename)
 	}
 
-	files, err := ioutil.ReadDir(raw_dir)
+	files, err := ioutil.ReadDir(rawDir)
 	if err != nil {
 		fmt.Printf("Error when updating map file: %s\n", err.Error())
 		os.Exit(1)
@@ -74,15 +74,15 @@ func updateMap() {
 			continue
 		}
 		key := strings.ToLower(split[0])
-		data[key] = fmt.Sprintf("%s/%s", raw_dir, file.Name())
+		data[key] = fmt.Sprintf("%s/%s", rawDir, file.Name())
 	}
 	b, err := json.Marshal(data)
 	if err != nil {
 		fmt.Printf("Error when updating map file: %s\n", err.Error())
 		os.Exit(1)
 	}
-	var map_file_path = fmt.Sprintf("%s/map.json", source_dir)
-	if err := ioutil.WriteFile(map_file_path, b, 0644); err != nil {
+	var mapFilePath = fmt.Sprintf("%s/map.json", sourceDir)
+	if err := ioutil.WriteFile(mapFilePath, b, 0644); err != nil {
 		fmt.Printf("Error when updating map file: %s\n", err.Error())
 		os.Exit(1)
 	}
@@ -92,10 +92,10 @@ func updateMap() {
 
 func listMap() map[string]string {
 	var (
-		data          map[string]string
-		map_file_path = fmt.Sprintf("%s/map.json", source_dir)
+		data        map[string]string
+		mapFilePath = fmt.Sprintf("%s/map.json", sourceDir)
 	)
-	f, err := os.Open(map_file_path)
+	f, err := os.Open(mapFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			fmt.Println("Map file not available, please run gitnore update")

--- a/map.go
+++ b/map.go
@@ -86,7 +86,7 @@ func updateMap() {
 		fmt.Printf("Error when updating map file: %s\n", err.Error())
 		os.Exit(1)
 	}
-	fmt.Println("Updating map file succed")
+	fmt.Println("Updating map file succeeded")
 	os.Exit(0)
 }
 
@@ -112,7 +112,7 @@ func listMap() map[string]string {
 }
 
 func printMap(data map[string]string) {
-	fmt.Println("List avaiables gitignore:")
+	fmt.Println("Available gitignore configurations:")
 	var keys []string
 	for key := range data {
 		keys = append(keys, key)


### PR DESCRIPTION
This resolves #1 

As specified in the issue, with this, multiple languages can be specified as a comma separated list while passing the src parameter. Take the following example:

```$ gitnore -i java,node,r```

This will create (or replace) a `.gitignore` file with the contents of the `java` configuration present, followed by the configuration for `node` and then `r` (with newline as padding between each)

The logic is pretty straightforward: The input is split, and iterated over for each language, where the contents of the destination is read, appended with the current configuration and written back until all languages are done. The README and command usage output are also modified to reflect this. Feel free to still review before merging.  
A different approach could be to read all the configurations serially, concatenate and then write directly once to the destination, however my goal was to make minimal changes over efficiency, so I did not bother.

Also note that along the way I've fixed some issues likes typos, bad grammar, and identifier names not following convention.